### PR TITLE
fix(widgets): 顶栏在macos因为被状态栏遮挡导致无法隐藏的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ __pycache__/
 
 # C extensions
 *.so
-
+configs/*
+RinUI/*
 # Distribution / packaging
 .Python
 build/

--- a/src/qml/ClassWidgets/components/WidgetsContainer.qml
+++ b/src/qml/ClassWidgets/components/WidgetsContainer.qml
@@ -7,10 +7,9 @@ import Widgets
 import ClassWidgets.Easing
 
 
-Flow {
+Item {
     id: widgetsContainer
     property real scaleFactor: Configs.data.preferences.scale_factor || 1.0
-    spacing: 8
 
     property bool editMode: false
     property bool menuVisible: false
@@ -22,6 +21,10 @@ Flow {
     property real dragOffsetX: 0
     property real dragOffsetY: 0
     property real hideMargin: 24  // 隐藏时保留的可点击空间
+    property real macOSMenuBarHeight: (Qt.platform.os === "osx") ? 32 : 0 // macOS 菜单栏避让高度
+
+    width: flowLayout.width
+    height: flowLayout.height
 
     Component.onCompleted: {
         editMode = widgetRepeater.count === 0
@@ -52,13 +55,15 @@ Flow {
     // 计算 Y 坐标
     function calcY() {
         let y = 0
+        let currentMenuBarHeight = (preferences.widgets_anchor.indexOf("top") !== -1) ? macOSMenuBarHeight : 0
+
         switch (preferences.widgets_anchor) {
         case "top_left":
         case "top_right":
             if (editMode) {
                 y = (Screen.height - height) / 2
             } else {
-                y = preferences.widgets_offset_y
+                y = preferences.widgets_offset_y + currentMenuBarHeight
                 // 左/右不受 hide 影响
             }
             break
@@ -66,8 +71,8 @@ Flow {
             if (editMode) {
                 y = (Screen.height - height) / 2
             } else {
-                y = preferences.widgets_offset_y
-                if (hide) y = -height + hideMargin  // 仅 center 生效
+                y = preferences.widgets_offset_y + currentMenuBarHeight
+                if (hide) y = -height + hideMargin + currentMenuBarHeight
             }
             break
         case "bottom_left":
@@ -77,7 +82,7 @@ Flow {
             break
         case "bottom_center":
             y = parent.height - height - preferences.widgets_offset_y
-            if (hide) y = parent.height - hideMargin // 仅 center 生效
+            if (hide) y = parent.height - hideMargin
             break
         }
 
@@ -109,15 +114,6 @@ Flow {
         }
     }
 
-    move: Transition {
-        enabled: editMode
-        NumberAnimation {
-            properties: "x,y"
-            duration: 300
-            easing.type: Easing.OutQuint
-        }
-    }
-
     Behavior on opacity {
         NumberAnimation {
             duration: 200
@@ -125,196 +121,229 @@ Flow {
         }
     }
 
-
-    Repeater {
-        id: widgetRepeater
-        model: WidgetsModel
-
-        delegate: Item {
-            id: widgetContainer
-            width: loader.width * scaleFactor
-            height: loader.height * scaleFactor
-            rotation: editMode
-            z: dragHandler.active ? 1 : 0
-            opacity: dragHandler.active ? 0.5 : 1
-
-            WidgetLoader {
-                id: loader
-                scale: tapHandler.pressed ? scaleFactor * 0.975 : scaleFactor
-
-                TapHandler {
-                    id: tapHandler
+    // 点击背景切换隐藏状态（处理小组件之间的间隙）
+    MouseArea {
+        id: backgroundClickArea
+        anchors.fill: parent
+        z: -1
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: (mouse) => {
+            if (mouse.button === Qt.LeftButton) {
+                if (Configs.data.interactions.hide.clicked) {
+                    Configs.set("interactions.hide.state", !hide)
                 }
-
-                Behavior on scale {
-                    NumberAnimation {
-                        duration: 400;
-                        easing.type: Easing.Bezier
-                        easing.bezierCurve: BezierCurve.liquidBack
-                    }
-                }
-            }
-
-            ToolButton {
-                id: deleteBtn
-                visible: widgetsContainer.editMode
-                icon.name: "ic_fluent_line_horizontal_1_20_filled"
-                size: 12
-                width: 24
-                height: 24
-                anchors.top: parent.top
-                anchors.left: parent.left
-                onClicked: WidgetsModel.removeInstance(model.instanceId)
-            }
-
-            // 拖拽
-            DragHandler {
-                id: dragHandler
-                enabled: widgetsContainer.editMode
-                property var originalX: parent.x
-                property var originalY: parent.y
-                onActiveChanged: {
-                    if (active) {
-                        originalX = parent.x
-                        originalY = parent.y
-                    }
-                    if (!active) {
-                        var from = index
-                        var to = Math.round(widgetContainer.x / (widgetContainer.width + widgetsContainer.spacing))
-                        if (to < 0) to = 0
-                        if (to >= widgetRepeater.count) to = widgetRepeater.count - 1
-                        if (to !== from) {
-                            WidgetsModel.moveInstance(from, to)
-                        } else {
-                            x = originalX
-                            y = originalY
-                        }
-                    }
-                }
-            }
-
-            // 右键菜单
-            Menu {
-                id: widgetMenu
-                onVisibleChanged: widgetsContainer.menuVisible = visible;
-                MenuItem {
-                    icon.name: "ic_fluent_info_20_regular"
-                    text: qsTr("Edit ") + "\"" + model.name + "\""
-                    onTriggered: {
-                        if (model.settingsQml) {
-                            widgetsContainer.editMode = true
-                            settingsDialog.setSource(model.settingsQml, {
-                                "settings": model.settings,
-                                "instanceId": model.instanceId
-                            })
-                            settingsDialog.open()
-                        }
-                    }
-                    enabled: model.settingsQml
-                }
-                MenuItem {
-                    icon.name: "ic_fluent_delete_20_regular"
-                    text: qsTr("Delete")
-                    onTriggered: {
-                        // widgetsContainer.editMode = true
-                        WidgetsModel.removeInstance(model.instanceId)
-                    }
-                }
-                MenuSeparator { visible: true }
-                MenuItem {
-                    icon.name: "ic_fluent_column_edit_20_regular"
-                    text: qsTr("Edit Widgets Screen")
-                    onTriggered: widgetsContainer.editMode = true
-                }
-            }
-
-            // 鼠标右键打开设置
-            TapHandler {
-                acceptedButtons: Qt.RightButton
-                onTapped: (point, button) => {
-                    if (button === Qt.RightButton) {
-                        widgetMenu.open()
-                    }
-                }
-            }
-
-            // 动画
-            SequentialAnimation on rotation {
-                id: rotationAnim
-                property real angle1: 2.0
-                property real angle2: -2.0
-                running: editMode
-                loops: Animation.Infinite
-
-                NumberAnimation { to: rotationAnim.angle1; duration: 125; easing.type: Easing.InOutQuad }
-                NumberAnimation { to: rotationAnim.angle2; duration: 125; easing.type: Easing.InOutQuad }
-
-                onRunningChanged: {
-                    rotationAnim.angle1 = Math.random() * 2.0
-                    rotationAnim.angle2 = -(Math.random() * 2.0)
-                }
-            }
-
-            SequentialAnimation {
-                id: anim
-                NumberAnimation { target: widgetContainer; property: "opacity"; from: 0; to: 0; duration: 1 }
-                PauseAnimation { duration: index * 125 }
-                ParallelAnimation {
-                    NumberAnimation {
-                        target: widgetContainer
-                        property: "opacity"
-                        from: 0; to: 1; duration: 300
-                        easing.type: Easing.OutCubic
-                    }
-                    NumberAnimation {
-                        target: widgetContainer;
-                        property: "scale";
-                        from: 0.8; to: 1; duration: 400;
-                        easing.type: Easing.OutBack
-                    }
-                }
-            }
-
-            Behavior on opacity {
-                NumberAnimation { duration: 100 }
             }
         }
     }
 
-    // 添加小组件&完成
-    ColumnLayout {
-        objectName: "addWidgetsContainer"
-        visible: widgetsContainer.editMode || widgetRepeater.count === 0
-        width: height
-        height: widgetRepeater.count > 0 ? widgetRepeater.itemAt(0).height: 100 * scaleFactor
+    Flow {
+        id: flowLayout
+        spacing: 8
 
-        Button {
-            id: addWidgetButton
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-
-            ColumnLayout {
-                anchors.centerIn: parent
-                Icon { Layout.alignment: Qt.AlignCenter; name: "ic_fluent_add_20_regular"; size: 18 }
-                Text {
-                    Layout.alignment: Qt.AlignCenter; text: qsTr("Add");
-                    visible: addWidgetButton.height > acceptButton.height
-                }
-            }
-
-            onClicked: {
-                widgetsContainer.editMode = true
-                addDialog.open()
+        move: Transition {
+            enabled: editMode
+            NumberAnimation {
+                properties: "x,y"
+                duration: 300
+                easing.type: Easing.OutQuint
             }
         }
 
-        Button {
-            visible: widgetsContainer.editMode
-            id: acceptButton
-            highlighted: true
-            Layout.fillWidth: true
-            icon.name: "ic_fluent_checkmark_20_regular"
-            onClicked: widgetsContainer.editMode = false
+        Repeater {
+            id: widgetRepeater
+            model: WidgetsModel
+
+            delegate: Item {
+                id: widgetDelegate
+                width: loader.width * scaleFactor
+                height: loader.height * scaleFactor
+                rotation: editMode
+                z: dragHandler.active ? 1 : 0
+                opacity: dragHandler.active ? 0.5 : 1
+
+                WidgetLoader {
+                    id: loader
+                    scale: loaderTapHandler.pressed ? scaleFactor * 0.975 : scaleFactor
+
+                    TapHandler {
+                        id: loaderTapHandler
+                        onTapped: {
+                            if (Configs.data.interactions.hide.clicked) {
+                                Configs.set("interactions.hide.state", !hide)
+                            }
+                        }
+                    }
+
+                    Behavior on scale {
+                        NumberAnimation {
+                            duration: 400;
+                            easing.type: Easing.Bezier
+                            easing.bezierCurve: BezierCurve.liquidBack
+                        }
+                    }
+                }
+
+                ToolButton {
+                    id: deleteBtn
+                    visible: widgetsContainer.editMode
+                    icon.name: "ic_fluent_line_horizontal_1_20_filled"
+                    size: 12
+                    width: 24
+                    height: 24
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    onClicked: WidgetsModel.removeInstance(model.instanceId)
+                }
+
+                // 拖拽
+                DragHandler {
+                    id: dragHandler
+                    enabled: widgetsContainer.editMode
+                    property var originalX: parent.x
+                    property var originalY: parent.y
+                    onActiveChanged: {
+                        if (active) {
+                            originalX = parent.x
+                            originalY = parent.y
+                        }
+                        if (!active) {
+                            var from = index
+                            var to = Math.round(widgetDelegate.x / (widgetDelegate.width + flowLayout.spacing))
+                            if (to < 0) to = 0
+                            if (to >= widgetRepeater.count) to = widgetRepeater.count - 1
+                            if (to !== from) {
+                                WidgetsModel.moveInstance(from, to)
+                            } else {
+                                x = originalX
+                                y = originalY
+                            }
+                        }
+                    }
+                }
+
+                // 右键菜单
+                Menu {
+                    id: widgetMenu
+                    onVisibleChanged: widgetsContainer.menuVisible = visible;
+                    MenuItem {
+                        icon.name: "ic_fluent_info_20_regular"
+                        text: qsTr("Edit ") + "\"" + model.name + "\""
+                        onTriggered: {
+                            if (model.settingsQml) {
+                                widgetsContainer.editMode = true
+                                settingsDialog.setSource(model.settingsQml, {
+                                    "settings": model.settings,
+                                    "instanceId": model.instanceId
+                                })
+                                settingsDialog.open()
+                            }
+                        }
+                        enabled: model.settingsQml
+                    }
+                    MenuItem {
+                        icon.name: "ic_fluent_delete_20_regular"
+                        text: qsTr("Delete")
+                        onTriggered: {
+                            // widgetsContainer.editMode = true
+                            WidgetsModel.removeInstance(model.instanceId)
+                        }
+                    }
+                    MenuSeparator { visible: true }
+                    MenuItem {
+                        icon.name: "ic_fluent_column_edit_20_regular"
+                        text: qsTr("Edit Widgets Screen")
+                        onTriggered: widgetsContainer.editMode = true
+                    }
+                }
+
+                // 鼠标右键打开设置
+                TapHandler {
+                    acceptedButtons: Qt.RightButton
+                    onTapped: (point, button) => {
+                        if (button === Qt.RightButton) {
+                            widgetMenu.open()
+                        }
+                    }
+                }
+
+                // 动画
+                SequentialAnimation on rotation {
+                    id: rotationAnim
+                    property real angle1: 2.0
+                    property real angle2: -2.0
+                    running: editMode
+                    loops: Animation.Infinite
+
+                    NumberAnimation { to: rotationAnim.angle1; duration: 125; easing.type: Easing.InOutQuad }
+                    NumberAnimation { to: rotationAnim.angle2; duration: 125; easing.type: Easing.InOutQuad }
+
+                    onRunningChanged: {
+                        rotationAnim.angle1 = Math.random() * 2.0
+                        rotationAnim.angle2 = -(Math.random() * 2.0)
+                    }
+                }
+
+                SequentialAnimation {
+                    id: anim
+                    NumberAnimation { target: widgetDelegate; property: "opacity"; from: 0; to: 0; duration: 1 }
+                    PauseAnimation { duration: index * 125 }
+                    ParallelAnimation {
+                        NumberAnimation {
+                            target: widgetDelegate
+                            property: "opacity"
+                            from: 0; to: 1; duration: 300
+                            easing.type: Easing.OutCubic
+                        }
+                        NumberAnimation {
+                            target: widgetDelegate;
+                            property: "scale";
+                            from: 0.8; to: 1; duration: 400;
+                            easing.type: Easing.OutBack
+                        }
+                    }
+                }
+
+                Behavior on opacity {
+                    NumberAnimation { duration: 100 }
+                }
+            }
+        }
+
+        // 添加小组件&完成
+        ColumnLayout {
+            objectName: "addWidgetsContainer"
+            visible: widgetsContainer.editMode || widgetRepeater.count === 0
+            width: height
+            height: widgetRepeater.count > 0 ? widgetRepeater.itemAt(0).height: 100 * scaleFactor
+
+            Button {
+                id: addWidgetButton
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                ColumnLayout {
+                    anchors.centerIn: parent
+                    Icon { Layout.alignment: Qt.AlignCenter; name: "ic_fluent_add_20_regular"; size: 18 }
+                    Text {
+                        Layout.alignment: Qt.AlignCenter; text: qsTr("Add");
+                        visible: addWidgetButton.height > acceptButton.height
+                    }
+                }
+
+                onClicked: {
+                    widgetsContainer.editMode = true
+                    addDialog.open()
+                }
+            }
+
+            Button {
+                visible: widgetsContainer.editMode
+                id: acceptButton
+                highlighted: true
+                Layout.fillWidth: true
+                icon.name: "ic_fluent_checkmark_20_regular"
+                onClicked: widgetsContainer.editMode = false
+            }
         }
     }
 

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,7 @@ version = "2.0.0.dev20251027"
 source = { virtual = "." }
 dependencies = [
     { name = "loguru" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyside6" },
     { name = "pyyaml" },
@@ -77,11 +78,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "loguru" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyside6", specifier = "~=6.9.3" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "rinui", specifier = ">=0.1.9" },
+    { name = "rinui", specifier = ">=0.1.9.1" },
 ]
 
 [[package]]
@@ -122,6 +124,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -291,16 +302,16 @@ wheels = [
 
 [[package]]
 name = "rinui"
-version = "0.1.9"
+version = "0.1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "darkdetect" },
     { name = "pyside6" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/70/e1276667788616df81da3bdcfe324fc5dc65dd8c8fdb4de0a9aa4e5be5f3/rinui-0.1.9.tar.gz", hash = "sha256:c7a1a88e77902ed054d5aa8e6dc6eacaff72f6aaba7a78e9b35149ed57d6a8a6", size = 897241, upload-time = "2025-10-26T05:52:38.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/0f/4b33e5a7ec1ab4258512103110e87ebbb87ff637e1b04bd4ef97293f2051/rinui-0.1.9.1.tar.gz", hash = "sha256:a63ccca9bb4a90e325ff98ee4f4bb3ee0c8b9b1622827c80231b8993ff361072", size = 890243, upload-time = "2025-12-20T14:15:06.428Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/32/93efe771ced24aaf52eae583d702501236666f572b8c46777ae0d505e865/rinui-0.1.9-py3-none-any.whl", hash = "sha256:e88fcf26151accdb34c911fbca42a24cfbe7ac7f2870369f00d3fc0661e5a874", size = 948638, upload-time = "2025-10-26T05:52:36.354Z" },
+    { url = "https://files.pythonhosted.org/packages/af/06/4bd46f6ea8fcc5252b60192c5bf0fee9529ec4c09d04443ab09b6d8aa2d0/rinui-0.1.9.1-py3-none-any.whl", hash = "sha256:08bf926ff24319aae2531ea086c56e0679b84ff4723ec6ed1656c374e5f3c3ec", size = 949001, upload-time = "2025-12-20T14:15:04.643Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
现在通过在macos中将顶栏露出一点点，这样让鼠标可以正常点击到，至于如何在完全隐藏的方法并不存在，在macos26（之前的我忘了）及以上版本任何应用都不能遮挡顶栏，所以此问题无解，目前已是最优解决方案，如果有更好的解决方案请在本PR讨论，谢谢