### PR TITLE
将“英语”修改为“外语”

### DIFF
--- a/src/core/utils/subjects.py
+++ b/src/core/utils/subjects.py
@@ -4,7 +4,7 @@ from src.core.schedule.model import Subject
 DEFAULT_SUBJECTS = [
     {"id": "chinese", "name": "Chinese", "simplifiedName": "CHN", "icon": "ic_fluent_book_20_regular", "color": "#FF5722", "isLocalClassRoom": True},
     {"id": "math", "name": "Mathematics", "simplifiedName": "Math", "icon": "ic_fluent_ruler_20_regular", "color": "#3F51B5", "isLocalClassRoom": True},
-    {"id": "english", "name": "English", "simplifiedName": "Eng", "icon": "ic_fluent_text_list_abc_uppercase_ltr_20_filled", "color": "#2196F3", "isLocalClassRoom": True},
+    {"id": "english", "name": "Foreign language", "simplifiedName": "FL", "icon": "ic_fluent_translate_20_regular", "color": "#2196F3", "isLocalClassRoom": True},
     {"id": "politics", "name": "Politics", "simplifiedName": "Civics", "icon": "ic_fluent_book_globe_20_regular", "color": "#9C27B0", "isLocalClassRoom": True},
     {"id": "history", "name": "History", "simplifiedName": "Hist", "icon": "ic_fluent_clock_20_regular", "color": "#795548", "isLocalClassRoom": True},
     {"id": "physics", "name": "Physics", "simplifiedName": "Phys", "icon": "ic_fluent_lightbulb_filament_20_regular", "color": "#00BCD4", "isLocalClassRoom": True},
@@ -44,7 +44,7 @@ def translate_sources():
     # full names
     QCoreApplication.translate("Subjects", "Chinese")
     QCoreApplication.translate("Subjects", "Mathematics")
-    QCoreApplication.translate("Subjects", "English")
+    QCoreApplication.translate("Subjects", "Foreign language")
     QCoreApplication.translate("Subjects", "Politics")
     QCoreApplication.translate("Subjects", "History")
     QCoreApplication.translate("Subjects", "Physics")
@@ -69,7 +69,7 @@ def translate_sources():
     # simplified names
     QCoreApplication.translate("SubjectsSimplified", "CHN")
     QCoreApplication.translate("SubjectsSimplified", "Math")
-    QCoreApplication.translate("SubjectsSimplified", "Eng")
+    QCoreApplication.translate("SubjectsSimplified", "FL")
     QCoreApplication.translate("SubjectsSimplified", "Civics")
     QCoreApplication.translate("SubjectsSimplified", "Hist")
     QCoreApplication.translate("SubjectsSimplified", "Phys")

--- a/src/core/utils/subjects.py
+++ b/src/core/utils/subjects.py
@@ -4,7 +4,7 @@ from src.core.schedule.model import Subject
 DEFAULT_SUBJECTS = [
     {"id": "chinese", "name": "Chinese", "simplifiedName": "CHN", "icon": "ic_fluent_book_20_regular", "color": "#FF5722", "isLocalClassRoom": True},
     {"id": "math", "name": "Mathematics", "simplifiedName": "Math", "icon": "ic_fluent_ruler_20_regular", "color": "#3F51B5", "isLocalClassRoom": True},
-    {"id": "english", "name": "Foreign language", "simplifiedName": "FL", "icon": "ic_fluent_translate_20_regular", "color": "#2196F3", "isLocalClassRoom": True},
+    {"id": "fl", "name": "Foreign language", "simplifiedName": "FL", "icon": "ic_fluent_translate_20_regular", "color": "#2196F3", "isLocalClassRoom": True},
     {"id": "politics", "name": "Politics", "simplifiedName": "Civics", "icon": "ic_fluent_book_globe_20_regular", "color": "#9C27B0", "isLocalClassRoom": True},
     {"id": "history", "name": "History", "simplifiedName": "Hist", "icon": "ic_fluent_clock_20_regular", "color": "#795548", "isLocalClassRoom": True},
     {"id": "physics", "name": "Physics", "simplifiedName": "Phys", "icon": "ic_fluent_lightbulb_filament_20_regular", "color": "#00BCD4", "isLocalClassRoom": True},


### PR DESCRIPTION
将“英语”修改为“外语”，让小语种用户可以开箱即用