### PR TITLE
fix: 重启时 QML 路径找不到导致的崩溃

### DIFF
--- a/src/core/central.py
+++ b/src/core/central.py
@@ -259,7 +259,12 @@ class AppCentral(QObject):  # Class Widgets 的中枢
     @Slot()
     def restart(self):
         self.cleanup()
-        os.execl(sys.executable, sys.executable, *sys.argv)
+        os.execl(
+            sys.executable,
+            sys.executable,
+            os.path.abspath(sys.argv[0]),
+            *sys.argv[1:],
+        )
 
     def setup_qml_context(self, window: QmlContextWindow) -> None:
         """

--- a/src/core/directories.py
+++ b/src/core/directories.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from PySide6.QtCore import QObject, Slot
 
 # Define paths
-SRC_PATH = Path(__file__).parents[1]
+SRC_PATH = Path(__file__).resolve().parents[1]
 ROOT_PATH = SRC_PATH.parent
 
 ASSETS_PATH = SRC_PATH.parent / "assets"


### PR DESCRIPTION
> 👇agent 写的，崩溃是偶发现象

## 问题现象

在主程序点"重启"功能时崩溃，报错：
```
Traceback (most recent call last):
  File "app.py", line 13, in <module>
  File "src\core\central.py", line 88, in __init__
  File "src\core\central.py", line 163, in _initialize_ui_components
  File "src\core\windows\windows.py", line 93, in __init__
  File "RinUI\core\launcher.py", line 66, in load
FileNotFoundError: Cannot find RinUI module: H:\ClassWidgets-2\Class Widgets 2.0.0.dev20260517-alpha
```
> 真人批注：虽然报错是 dev20260517-alpha 报的，但新版源码这块儿逻辑没变

## 根因

主程序用相对路径解析 QML，依赖当前工作目录 cwd；重启后 cwd 变化时找不到 QML 文件：

1. `src/core/directories.py`：`SRC_PATH = Path(__file__).parents[1]` 未 `.resolve()`，当 `__file__` 为相对路径时 `SRC_PATH`/`CW_PATH` 为相对路径，`QML.exists()` 取决于 cwd。
2. `src/core/central.py` 的 `restart()`：`os.execl(...)` 使用 `*sys.argv`，若 `sys.argv[0]` 为相对路径，重启后路径基准依赖 cwd。

## 修改内容

- `directories.py`：`SRC_PATH` 改用 `Path(__file__).resolve().parents[1]`，使 `ROOT_PATH`/`QML_PATH`/`CW_PATH`/`CONFIGS_PATH` 等全部自动变为绝对路径。
- `central.py`：`restart()` 改用 `os.path.abspath(sys.argv[0])` 以绝对脚本路径重启。

## 验证

- 从项目根目录及 `C:\` 两种 cwd 启动，路径均正确解析，不再依赖 cwd。
- GUI 下点"重启"可正常重新加载 QML。


