### PR TITLE
fix: auto-scale overflow widgets in edit mode and reduce lag

### DIFF
--- a/src/qml/ClassWidgets/Components/WidgetsContainer.qml
+++ b/src/qml/ClassWidgets/Components/WidgetsContainer.qml
@@ -32,7 +32,30 @@ Column {
     property bool isTopPosition: preferences.widgets_anchor.indexOf("top_") === 0
     property real hideFade: 0
 
+    // 超宽自适应：编辑模式下若整体宽度超出屏幕，自动等比缩小并提示
+    readonly property real availWidth: Math.max(240, Screen.width - 16)
+    readonly property real overflowScale: width > availWidth ? availWidth / width : 1.0
+    readonly property bool overflows: editMode && width > availWidth
+    scale: editMode ? overflowScale : 1.0
+    transformOrigin: Item.TopLeft
+
     signal contentGeometryChanged()
+
+    // 超宽提示条：仅在编辑模式且超宽时显示（字号/高度按缩放补偿，保持视觉大小不变）
+    Rectangle {
+        visible: widgetsContainer.editMode && widgetsContainer.overflows
+        width: parent.width
+        height: 30 / widgetsContainer.overflowScale
+        radius: 8
+        color: "#CC1F2937"
+        border.color: "#66FFC107"
+        Text {
+            anchors.centerIn: parent
+            text: "⚠ 当前布局可能已超出屏幕宽度，建议减少组件数量"
+            color: "#FFE082"
+            font.pixelSize: 12 / widgetsContainer.overflowScale
+        }
+    }
 
     Behavior on hideFade {
         NumberAnimation {
@@ -84,6 +107,10 @@ Column {
             x = parent.width - width - preferences.widgets_offset_x
             if (hide) x = parent.width - hideMargin
             break
+        }
+        // 编辑模式：整体居中并限制在屏幕内，避免两端组件被裁掉无法辨认
+        if (editMode) {
+            x = Math.max(8, (parent.width - width * overflowScale) / 2)
         }
         return x
     }
@@ -300,7 +327,7 @@ Column {
                     property real angle1: 2.0
                     property real angle2: -2.0
                     running: editMode
-                    loops: Animation.Infinite
+                    loops: 3
 
                     NumberAnimation { to: rotationAnim.angle1; duration: 125; easing.type: Easing.InOutQuad }
                     NumberAnimation { to: rotationAnim.angle2; duration: 125; easing.type: Easing.InOutQuad }

--- a/src/qml/ClassWidgets/Components/WidgetsContainer.qml
+++ b/src/qml/ClassWidgets/Components/WidgetsContainer.qml
@@ -342,18 +342,18 @@ Column {
                 SequentialAnimation {
                     id: anim
                     NumberAnimation { target: widgetContainer; property: "opacity"; from: 0; to: 0; duration: 1 }
-                    PauseAnimation { duration: index * 125 }
+                    PauseAnimation { duration: Math.min(index * 20, 100) }
                     ParallelAnimation {
                         NumberAnimation {
                             target: widgetContainer
                             property: "opacity"
-                            from: 0; to: 1; duration: 300
+                            from: 0; to: 1; duration: 200
                             easing.type: Easing.OutCubic
                         }
                         NumberAnimation {
                             target: widgetContainer;
                             property: "scale";
-                            from: 0.8; to: 1; duration: 400;
+                            from: 0.9; to: 1; duration: 250;
                             easing.type: Easing.OutBack
                         }
                     }


### PR DESCRIPTION
## 修复编辑模式下的两个问题

### 1. 修复组件超出屏幕宽度
- 添加自动缩放功能，当组件总宽度超出屏幕时自动缩小
- 添加警告横幅提示用户减少组件数量
- 限制组件位置防止超出屏幕边界

### 2. 修复编辑模式卡顿
- 将抖动动画从无限循环改为仅循环 3 次
- 减少不必要的重绘，显著提升性能

### 技术细节
- 添加 `availWidth`、`overflowScale`、`overflows` 属性
- 使用 `scale` 属性实现自动缩放
- 在 `calcX()` 中添加编辑模式位置限制
- 动画 `loops` 从 `Animation.Infinite` 改为 `3`