### PR TITLE
feat(settings): 为“预备铃”增加可自定义的提前分钟数

### DIFF
--- a/src/qml/ClassWidgets/pages/settings/notificationAndTime/Time.qml
+++ b/src/qml/ClassWidgets/pages/settings/notificationAndTime/Time.qml
@@ -40,4 +40,30 @@ FluentPage {
             }
         }
     }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 4
+        Text {
+            typography: Typography.BodyStrong
+            text: qsTr("Preparation Bell")
+        }
+
+        SettingCard {
+            Layout.fillWidth: true
+            icon.name: "ic_fluent_alert_20_regular"
+            title: qsTr("Advance Time (Minutes)")
+            description: qsTr("Minutes before class starts to ring the preparation bell")
+
+            SpinBox {
+                from: 1
+                to: 60
+                Layout.preferredWidth: 200
+                enabled: !Configs.isKeyLocked("schedule.preparation_time")
+                // 仅在用户操作时写回；构造阶段 from 钳制产生的误写(1)不会覆盖真实配置
+                onValueChanged: if (focus) Configs.set("schedule.preparation_time", value)
+                Component.onCompleted: value = Configs.data.schedule.preparation_time
+            }
+        }
+    }
 }


### PR DESCRIPTION
预备铃目前的提前量固定为 2 分钟。配置模型 ScheduleConfig 里本就有 schedule.preparation_time（默认 2，运行时已实时读取并按其触发预备铃），但一直没有界面可修改。