### PR TITLE
feat: 按课程名称豁免“在课堂中隐藏”

### DIFF
--- a/src/core/automations/builtin_tasks.py
+++ b/src/core/automations/builtin_tasks.py
@@ -56,6 +56,7 @@ class AutoHideTask(AutomationTask):
         self._window_states: dict[int, dict[str, bool]] = {}
         self.previous_state: bool = False
         self._fullscreen_window: int | None = None
+        self._os_hiding: bool = False  # 当前是否因最大化/全屏而被自动隐藏
         
         # Check initial state on startup
         if self.app_central.configs.interactions.hide.in_class:
@@ -63,6 +64,37 @@ class AutoHideTask(AutomationTask):
 
         # Check initial maximize/fullscreen state on startup
         self.update()
+
+    def _subject_name(self, entry) -> str:
+        """取条目对应的课程名称（用于豁免名单匹配）。"""
+        if entry is None:
+            return ""
+        subject_id = getattr(entry, "subjectId", None)
+        name = ""
+        if subject_id:
+            try:
+                schedule = getattr(self.runtime, "schedule", None)
+                subjects = getattr(schedule, "subjects", None) if schedule else None
+                if subjects:
+                    subject = self.runtime.services.get_subject(subject_id, subjects)
+                    if subject:
+                        name = getattr(subject, "name", None) or ""
+                        if not name:
+                            name = getattr(subject, "simplifiedName", None) or ""
+            except Exception as e:
+                logger.debug(f"Failed to resolve subject name: {e}")
+        if not name:
+            name = getattr(entry, "title", None) or ""
+        return name
+
+    def _is_exempt(self, entry) -> bool:
+        """该课程是否在“不自动隐藏”豁免名单（按课程名称）。"""
+        if entry is None:
+            return False
+        names = self.app_central.configs.interactions.hide.no_hide_subjects or []
+        if not names:
+            return False
+        return self._subject_name(entry) in names
 
     def _hide(self, state: bool) -> None:
         """隐藏窗口"""
@@ -119,6 +151,7 @@ class AutoHideTask(AutomationTask):
 
         if new_state != self.previous_state:
             self._hide(new_state)
+            self._os_hiding = new_state
         self.previous_state = new_state
 
     def _enum_windows_callback(self, hwnd: int, _) -> bool:
@@ -142,7 +175,16 @@ class AutoHideTask(AutomationTask):
 
     def on_schedule_changed(self, current_type: EntryType) -> None:
         """课程发生变化触发"""
-        if not self.app_central.configs.interactions.hide.in_class:  # 未开启设置
+        cfg = self.app_central.configs.interactions.hide
+        if not cfg.in_class:  # 未开启设置
             return
 
-        self._hide(current_type == EntryType.CLASS or current_type == EntryType.ACTIVITY)
+        hide_now = current_type == EntryType.CLASS or current_type == EntryType.ACTIVITY
+        # 豁免课程（按名称）：上课期间不自动隐藏；若正被隐藏则恢复显示。
+        # 若隐藏由全屏/最大化触发，则不强行恢复。
+        if hide_now and cfg.action == TapAction.HIDE and not self._os_hiding \
+                and self._is_exempt(self.runtime.current_entry):
+            cfg.state = False
+            return
+
+        self._hide(hide_now)

--- a/src/core/config/model.py
+++ b/src/core/config/model.py
@@ -129,6 +129,7 @@ class HideInteractionsConfig(ConfigBaseModel):
     maximized: bool = False  # 窗口最大化
     fullscreen: bool = False   # 窗口全屏
     action: TapAction = TapAction.HIDE  # 触发隐藏时的行为（隐藏 / 切换迷你模式 / 浮窗）
+    no_hide_subjects: list[str] = Field(default_factory=list)  # 按课程名称豁免自动隐藏（对所有课表生效）
 
     class Config:
         use_enum_values = True

--- a/src/qml/ClassWidgets/pages/settings/General/Interactions.qml
+++ b/src/qml/ClassWidgets/pages/settings/General/Interactions.qml
@@ -14,6 +14,31 @@ FluentPage {
         return PathManager.images("tutorial/" + name + (Theme.isDark() ? "-dark.png" : "-light.png"))
     }
 
+    // ---- “不自动隐藏的课程”（按课程名称，逗号分隔，全局生效） ----
+    function exemptArray() {
+        // Configs.data 里的列表在 QML 侧不一定是 JS 数组（Array.isArray 为 false），
+        // 需按“类数组”安全展开。
+        const a = Configs.data.interactions.hide.no_hide_subjects
+        if (Array.isArray(a)) return a
+        const out = []
+        if (a && typeof a.length === "number") {
+            for (let i = 0; i < a.length; i++) out.push(a[i])
+        }
+        return out
+    }
+    function exemptText() {
+        return exemptArray().join("，")
+    }
+    function setExemptFromText(text) {
+        const parts = String(text || "").split(/[,，]/)
+        const out = []
+        for (const p of parts) {
+            const s = p.trim()
+            if (s && out.indexOf(s) < 0) out.push(s)
+        }
+        Configs.set("interactions.hide.no_hide_subjects", out)
+    }
+
     ColumnLayout {
         Layout.fillWidth: true
         spacing: 4
@@ -161,7 +186,25 @@ FluentPage {
                         onCheckedChanged: Configs.set("interactions.hide.fullscreen", checked)
                         Component.onCompleted: checked = Configs.data.interactions.hide.fullscreen
                     }
+
                 }
+            }
+        }
+
+        SettingCard {
+            Layout.fillWidth: true
+            icon.name: "ic_fluent_class_20_regular"
+            title: qsTr("Never auto-hide these courses")
+            description: qsTr("Separate with commas. These courses stay visible during class auto-hide.")
+
+            TextField {
+                id: exemptField
+                Layout.preferredWidth: 240
+                placeholderText: qsTr("e.g. Math, Chinese")
+                Component.onCompleted: text = root.exemptText()
+                onTextEdited: root.setExemptFromText(text)
+                onEditingFinished: root.setExemptFromText(text)
+                onAccepted: root.setExemptFromText(text)
             }
         }
     }


### PR DESCRIPTION
新增 interactions.hide.no_hide_subjects（课程名称列表，逗号分隔，对所有课表生效）：
- 开启“在课堂中隐藏”时，名单中的课程上课期间不会被自动隐藏；
